### PR TITLE
Update Texture2D interface

### DIFF
--- a/ExampleGame/Levels/debug.level
+++ b/ExampleGame/Levels/debug.level
@@ -3,6 +3,9 @@ Camera
     name "FreeCam"
     position [0.0 500.0 0.0]
     orientation [0.0 1.5707 0.0] // yaw, pitch, roll
+    znear 10.0
+    zfar 50000.0
+    fov 60.0
 }
 
 FreeRoamCameraController

--- a/GameEngineCore/AtmospherePostRenderPass.cpp
+++ b/GameEngineCore/AtmospherePostRenderPass.cpp
@@ -45,8 +45,8 @@ namespace GameEngine
 					List<float> irradianceData;
 					irradianceData.SetSize(16 * 64 * 3);
 					reader.Read(irradianceData.Buffer(), irradianceData.Count());
-					irradianceTex = hwRenderer->CreateTexture2D(TextureUsage::Sampled);
-					irradianceTex->SetData(StorageFormat::RGB_F16, 64, 16, 1, DataType::Float3, irradianceData.Buffer());
+					irradianceTex = hwRenderer->CreateTexture2D(TextureUsage::Sampled, 64, 16, 1, StorageFormat::RGB_F16);
+					irradianceTex->SetData(64, 16, 1, DataType::Float3, irradianceData.Buffer());
 				}
 				{
 					BinaryReader reader(new FileStream(inscatterDataFile));
@@ -66,8 +66,8 @@ namespace GameEngine
 					List<float> transmittanceData;
 					transmittanceData.SetSize(256 * 64 * 3);
 					reader.Read(transmittanceData.Buffer(), transmittanceData.Count());
-					transmittanceTex = hwRenderer->CreateTexture2D(TextureUsage::Sampled);
-					transmittanceTex->SetData(StorageFormat::RGB_F16, 0, 256, 64, 1, DataType::Float3, transmittanceData.Buffer());
+					transmittanceTex = hwRenderer->CreateTexture2D(TextureUsage::Sampled, 256, 64, 1, StorageFormat::RGB_F16);
+					transmittanceTex->SetData(0, 256, 64, 1, DataType::Float3, transmittanceData.Buffer());
 				}
 			}
 

--- a/GameEngineCore/GLAPI/GLHardwareRenderer.cpp
+++ b/GameEngineCore/GLAPI/GLHardwareRenderer.cpp
@@ -578,19 +578,13 @@ namespace GLL
 				if (samples > 1)
 				{
 					glBindTexture(GL_TEXTURE_2D, Handle);
-					if (!data)
-						glTexStorage2DMultisample(GL_TEXTURE_2D, samples, this->internalFormat, width, height, GL_TRUE);
-					else
-						glTexImage2DMultisample(GL_TEXTURE_2D, samples, this->internalFormat, width, height, GL_TRUE);
+					glTexImage2DMultisample(GL_TEXTURE_2D, samples, this->internalFormat, width, height, GL_TRUE);
 					glBindTexture(GL_TEXTURE_2D, 0);
 				}
 				else
 				{
 					glBindTexture(GL_TEXTURE_2D, Handle);
-					if (!data)
-						glTexStorage2D(GL_TEXTURE_2D, Math::Log2Ceil(Math::Max(width, height)), this->internalFormat, width, height);
-					else
-						glTexImage2D(GL_TEXTURE_2D, level, this->internalFormat, width, height, 0, this->format, this->type, data);
+					glTexImage2D(GL_TEXTURE_2D, level, this->internalFormat, width, height, 0, this->format, this->type, data);
 					glBindTexture(GL_TEXTURE_2D, 0);
 
 				}
@@ -2742,6 +2736,7 @@ namespace GLL
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 8.0f);
+			glTextureStorage2D(handle, mipLevelCount, TranslateStorageFormat(format), w, h);
 			glBindTexture(GL_TEXTURE_2D, 0);
 
 			auto rs = new Texture2D();

--- a/GameEngineCore/GameEngineCore.vcxproj
+++ b/GameEngineCore/GameEngineCore.vcxproj
@@ -195,7 +195,7 @@
     <ClCompile Include="TextureTool\LibSquish.cpp" />
     <ClCompile Include="UISystem_Windows.cpp" />
     <ClCompile Include="VulkanAPI\vkel.c" />
-    <ClCompile Include="VulkanHardwareRenderer.cpp" />
+    <ClCompile Include="VulkanAPI\VulkanHardwareRenderer.cpp" />
     <ClCompile Include="WorldRenderPass.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/GameEngineCore/GameEngineCore.vcxproj.filters
+++ b/GameEngineCore/GameEngineCore.vcxproj.filters
@@ -17,9 +17,6 @@
     <ClCompile Include="HardwareInputInterface.cpp" />
     <ClCompile Include="TextureCompressor.cpp" />
     <ClCompile Include="TextureTool\LibSquish.cpp" />
-    <ClCompile Include="VulkanHardwareRenderer.cpp">
-      <Filter>Renderer\RenderAPI\Vulkan API</Filter>
-    </ClCompile>
     <ClCompile Include="GLAPI\GLHardwareRenderer.cpp">
       <Filter>Renderer\RenderAPI\GL API</Filter>
     </ClCompile>
@@ -111,6 +108,9 @@
     </ClCompile>
     <ClCompile Include="DeviceMemory.cpp">
       <Filter>Renderer</Filter>
+    </ClCompile>
+    <ClCompile Include="VulkanAPI\VulkanHardwareRenderer.cpp">
+      <Filter>Renderer\RenderAPI\Vulkan API</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/GameEngineCore/HardwareRenderer.h
+++ b/GameEngineCore/HardwareRenderer.h
@@ -419,9 +419,8 @@ namespace GameEngine
 		Texture2D() {};
 	public:
 		virtual void GetSize(int& width, int& height) = 0;
-		virtual void Resize(int width, int height, int samples, int miplevels = 1, bool preserveData = false) = 0;
-		virtual void SetData(StorageFormat format, int level, int width, int height, int samples, DataType inputType, void* data, bool mipmapped = true) = 0;
-		virtual void SetData(StorageFormat format, int width, int height, int samples, DataType inputType, void* data, bool mipmapped = true) = 0;
+		virtual void SetData(int level, int width, int height, int samples, DataType inputType, void* data) = 0;
+		virtual void SetData(int width, int height, int samples, DataType inputType, void* data) = 0;
 		virtual void GetData(int mipLevel, void* data, int bufSize) = 0;
 		virtual void BuildMipmaps() = 0;
 	};
@@ -655,7 +654,7 @@ namespace GameEngine
 		virtual void Wait() = 0;
 		virtual Buffer* CreateBuffer(BufferUsage usage) = 0;
 		virtual Buffer* CreateMappedBuffer(BufferUsage usage) = 0;
-		virtual Texture2D* CreateTexture2D(TextureUsage usage) = 0;
+		virtual Texture2D* CreateTexture2D(TextureUsage usage, int width, int height, int mipLevelCount, StorageFormat format) = 0;
 		virtual Texture2DArray* CreateTexture2DArray(TextureUsage usage, int width, int height, int layers, int mipLevelCount, StorageFormat format) = 0;
 		virtual Texture3D* CreateTexture3D(TextureUsage usage, int width, int height, int depth, int mipLevelCount, StorageFormat format) = 0;
 		virtual TextureSampler * CreateTextureSampler() = 0;

--- a/GameEngineCore/RenderContext.cpp
+++ b/GameEngineCore/RenderContext.cpp
@@ -621,7 +621,6 @@ namespace GameEngine
 				result->Height = (int)(screenHeight * ratio);
 			}
 			result->Texture = hardwareRenderer->CreateTexture2D(TextureUsage::ColorAttachment, result->Width, result->Height, 1, format);
-			result->Texture->SetData(result->Width, result->Height, 1, GetStorageDataType(format), nullptr);//TODO: remove this line
 		}
 		result->FixedWidth = w;
 		result->FixedHeight = h;
@@ -639,7 +638,6 @@ namespace GameEngine
 				r.Value->Width = (int)(screenWidth * r.Value->ResolutionScale);
 				r.Value->Height = (int)(screenHeight * r.Value->ResolutionScale);
 				r.Value->Texture = hardwareRenderer->CreateTexture2D(TextureUsage::ColorAttachment, r.Value->Width, r.Value->Height, 1, r.Value->Format);
-				r.Value->Texture->SetData(r.Value->Width, r.Value->Height, 1, GetStorageDataType(r.Value->Format), nullptr);//TODO: remove this line
 			}
 		}
 		for (auto & output : renderOutputs)

--- a/GameEngineCore/RenderContext.cpp
+++ b/GameEngineCore/RenderContext.cpp
@@ -176,9 +176,9 @@ namespace GameEngine
 
 		auto hw = rendererResource->hardwareRenderer.Ptr();
 
-		auto rs = hw->CreateTexture2D(TextureUsage::Sampled);
+		auto rs = hw->CreateTexture2D(TextureUsage::Sampled, data.GetWidth(), data.GetHeight(), data.GetMipLevels(), format);
 		for (int i = 0; i < data.GetMipLevels(); i++)
-			rs->SetData(format, i, Math::Max(data.GetWidth() >> i, 1), Math::Max(data.GetHeight() >> i, 1), 1, dataType, data.GetData(i).Buffer());
+			rs->SetData(i, Math::Max(data.GetWidth() >> i, 1), Math::Max(data.GetHeight() >> i, 1), 1, dataType, data.GetData(i).Buffer());
 		if (format != StorageFormat::BC1 && format != StorageFormat::BC5)
 			rs->BuildMipmaps();
 		textures[name] = rs;
@@ -610,7 +610,6 @@ namespace GameEngine
 		result->UseFixedResolution = ratio == 0.0f;
 		if (screenWidth > 0 || result->UseFixedResolution)
 		{
-			result->Texture = hardwareRenderer->CreateTexture2D(TextureUsage::ColorAttachment);
 			if (ratio == 0.0f)
 			{
 				result->Width = w;
@@ -621,7 +620,8 @@ namespace GameEngine
 				result->Width = (int)(screenWidth * ratio);
 				result->Height = (int)(screenHeight * ratio);
 			}
-			result->Texture->SetData(format, result->Width, result->Height, 1, GetStorageDataType(format), nullptr);
+			result->Texture = hardwareRenderer->CreateTexture2D(TextureUsage::ColorAttachment, result->Width, result->Height, 1, format);
+			result->Texture->SetData(result->Width, result->Height, 1, GetStorageDataType(format), nullptr);//TODO: remove this line
 		}
 		result->FixedWidth = w;
 		result->FixedHeight = h;
@@ -636,11 +636,10 @@ namespace GameEngine
 		{
 			if (!r.Value->UseFixedResolution)
 			{
-				r.Value->Texture = hardwareRenderer->CreateTexture2D(TextureUsage::ColorAttachment);
 				r.Value->Width = (int)(screenWidth * r.Value->ResolutionScale);
 				r.Value->Height = (int)(screenHeight * r.Value->ResolutionScale);
-				r.Value->Texture->SetData(r.Value->Format, r.Value->Width,
-					r.Value->Height, 1, GetStorageDataType(r.Value->Format), nullptr);
+				r.Value->Texture = hardwareRenderer->CreateTexture2D(TextureUsage::ColorAttachment, r.Value->Width, r.Value->Height, 1, r.Value->Format);
+				r.Value->Texture->SetData(r.Value->Width, r.Value->Height, 1, GetStorageDataType(r.Value->Format), nullptr);//TODO: remove this line
 			}
 		}
 		for (auto & output : renderOutputs)

--- a/GameEngineCore/UISystem_Windows.cpp
+++ b/GameEngineCore/UISystem_Windows.cpp
@@ -750,7 +750,6 @@ namespace GraphicsUI
 			Matrix4::CreateOrthoMatrix(orthoMatrix, 0.0f, (float)screenWidth, 0.0f, (float)screenHeight, 1.0f, -1.0f);
 			uniformBuffer->SetData(&orthoMatrix, sizeof(orthoMatrix)); 
 			uiOverlayTexture = rendererApi->CreateTexture2D(TextureUsage::ColorAttachment, w, h, 1, StorageFormat::RGBA_8);
-			uiOverlayTexture->SetData(w, h, 1, DataType::Byte4, nullptr);//TODO: delete this line
 			frameBuffer = renderTargetLayout->CreateFrameBuffer(MakeArrayView(uiOverlayTexture.Ptr()));
 		}
 		void BeginUIDrawing()

--- a/GameEngineCore/UISystem_Windows.cpp
+++ b/GameEngineCore/UISystem_Windows.cpp
@@ -724,8 +724,7 @@ namespace GraphicsUI
 			linearSampler = rendererApi->CreateTextureSampler();
 			linearSampler->SetFilter(TextureFilter::Linear);
 
-			uiOverlayTexture = rendererApi->CreateTexture2D(TextureUsage::ColorAttachment);
-			uiOverlayTexture->Resize(4, 4, 1);
+			uiOverlayTexture = rendererApi->CreateTexture2D(TextureUsage::ColorAttachment, 4, 4, 1, StorageFormat::RGBA_8);
 			frameBuffer = renderTargetLayout->CreateFrameBuffer(MakeArrayView(uiOverlayTexture.Ptr()));
 
 			descSet = rendererApi->CreateDescriptorSet(descLayout.Ptr());
@@ -750,8 +749,8 @@ namespace GraphicsUI
 			rendererApi->Wait();
 			Matrix4::CreateOrthoMatrix(orthoMatrix, 0.0f, (float)screenWidth, 0.0f, (float)screenHeight, 1.0f, -1.0f);
 			uniformBuffer->SetData(&orthoMatrix, sizeof(orthoMatrix)); 
-			uiOverlayTexture = rendererApi->CreateTexture2D(TextureUsage::ColorAttachment);
-			uiOverlayTexture->SetData(GameEngine::StorageFormat::RGBA_8, w, h, 1, DataType::Byte4, nullptr, false);
+			uiOverlayTexture = rendererApi->CreateTexture2D(TextureUsage::ColorAttachment, w, h, 1, StorageFormat::RGBA_8);
+			uiOverlayTexture->SetData(w, h, 1, DataType::Byte4, nullptr);//TODO: delete this line
 			frameBuffer = renderTargetLayout->CreateFrameBuffer(MakeArrayView(uiOverlayTexture.Ptr()));
 		}
 		void BeginUIDrawing()
@@ -949,9 +948,8 @@ namespace GraphicsUI
 		UIImage(UIWindowsSystemInterface* ctx, const CoreLib::Imaging::Bitmap & bmp)
 		{
 			context = ctx;
-			texture = context->rendererApi->CreateTexture2D(TextureUsage::Sampled);
-			texture->SetData(bmp.GetIsTransparent() ? StorageFormat::RGBA_I8 : StorageFormat::RGB_I8, bmp.GetWidth(), bmp.GetHeight(), 1,
-				bmp.GetIsTransparent() ? DataType::Byte4 : DataType::Byte, bmp.GetPixels());
+			texture = context->rendererApi->CreateTexture2D(TextureUsage::Sampled, bmp.GetWidth(), bmp.GetHeight(), 1, bmp.GetIsTransparent() ? StorageFormat::RGBA_I8 : StorageFormat::RGB_I8);
+			texture->SetData(bmp.GetWidth(), bmp.GetHeight(), 1, bmp.GetIsTransparent() ? DataType::Byte4 : DataType::Byte, bmp.GetPixels());
 			w = bmp.GetWidth();
 			h = bmp.GetHeight();
 		}

--- a/GameEngineCore/VulkanAPI/VulkanHardwareRenderer.cpp
+++ b/GameEngineCore/VulkanAPI/VulkanHardwareRenderer.cpp
@@ -1,9 +1,9 @@
-#include "HardwareRenderer.h"
+#include "../GameEngineCore/HardwareRenderer.h"
 
-#if (0)
-#include "VulkanAPI/vkel.h"
+#if(0)
+#include "vkel.h"
 //#define VK_CPP_NO_EXCEPTIONS
-#include "VulkanAPI/vk_cpp.hpp"
+#include "vk_cpp.hpp"
 
 #include "CoreLib/WinForm/Debug.h"
 #include "CoreLib/VectorMath.h"

--- a/GameEngineCore/VulkanAPI/VulkanHardwareRenderer.cpp
+++ b/GameEngineCore/VulkanAPI/VulkanHardwareRenderer.cpp
@@ -755,7 +755,7 @@ namespace VK
 		case StorageFormat::RGB10_A2: return vk::Format::eA2R10G10B10UnormPack32;//
 		case StorageFormat::Depth32: return vk::Format::eD32Sfloat;
 		case StorageFormat::Depth24Stencil8: return vk::Format::eD24UnormS8Uint;
-		default: throw HardwareRendererException("Not implemented.");
+		default: throw CoreLib::NotImplementedException();
 		}
 	};
 
@@ -767,7 +767,7 @@ namespace VK
 		case BufferUsage::IndexBuffer: return vk::BufferUsageFlagBits::eIndexBuffer;
 		case BufferUsage::StorageBuffer: return vk::BufferUsageFlagBits::eStorageBuffer;
 		case BufferUsage::UniformBuffer: return vk::BufferUsageFlagBits::eUniformBuffer;
-		default: throw HardwareRendererException("Not implemented.");
+		default: throw CoreLib::NotImplementedException();
 		}
 	}
 
@@ -848,7 +848,7 @@ namespace VK
 		case BindingType::UniformBuffer: return vk::DescriptorType::eUniformBuffer; //TODO: dynamic?
 		case BindingType::StorageBuffer: return vk::DescriptorType::eStorageBuffer; //TODO: ^
 		case BindingType::Unused: throw HardwareRendererException("Attempting to use unused binding");
-		default: throw HardwareRendererException("Not implemented");
+		default: throw CoreLib::NotImplementedException();
 		}
 	}
 
@@ -864,7 +864,7 @@ namespace VK
 		case TextureUsage::SampledDepthAttachment:
 			return vk::ImageLayout::eDepthStencilAttachmentOptimal;
 		case TextureUsage::Sampled: return vk::ImageLayout::eShaderReadOnlyOptimal;
-		default: throw HardwareRendererException("Not implemented");
+		default: throw CoreLib::NotImplementedException();
 		}
 	}
 
@@ -969,14 +969,9 @@ namespace VK
 		case ShaderType::VertexShader: return vk::ShaderStageFlagBits::eVertex;
 		case ShaderType::FragmentShader: return vk::ShaderStageFlagBits::eFragment;
 		case ShaderType::ComputeShader: return vk::ShaderStageFlagBits::eCompute;
-		default: throw HardwareRendererException("Not implemented.");
+		default: throw CoreLib::NotImplementedException();
 		}
 	}
-
-	class RenderBuffer
-	{
-
-	};
 
 	class Texture : public CoreLib::Object
 	{
@@ -986,59 +981,12 @@ namespace VK
 		vk::DeviceMemory memory;
 		StorageFormat format;
 		TextureUsage usage;
-
-		Texture(TextureUsage usage)
+		Texture(TextureUsage usage, int width, int height, int depth, int mipLevels, int arrayLayers, int numSamples, StorageFormat format)
 		{
 			this->usage = usage;
-			if (!!(usage & TextureUsage::DepthAttachment))
-				this->format = StorageFormat::Depth32;
-			else if (!!(usage & TextureUsage::ColorAttachment))
-				this->format = StorageFormat::RGBA_8;
-			else if (!!(usage & TextureUsage::Sampled))
-				this->format = StorageFormat::RGBA_F32;
-		}
-		~Texture()
-		{
-			RendererState::Device().waitIdle(); //TODO: Remove
-			if (memory) RendererState::Device().freeMemory(memory);
-			if (view) RendererState::Device().destroyImageView(view);
-			if (image) RendererState::Device().destroyImage(image);
-		}
-	};
+			this->format = format;
 
-	class Texture2D : public VK::Texture, public GameEngine::Texture2D
-	{
-		//TODO: Need some way of determining layouts and performing transitions properly. 
-	public:
-		int width;
-		int height;
-		int samples = 1;
-		int mipLevels = 1;
-		vk::ImageLayout currentLayout;
-
-		Texture2D(TextureUsage usage) : VK::Texture(usage) {};
-
-		void GetSize(int& pwidth, int& pheight)
-		{
-			pwidth = width;
-			pheight = height;
-		}
-		void Resize(int newWidth, int newHeight, int newSamples, int newMipLevels = 1, bool preserveData = false)
-		{
-			if (this->width == newWidth && this->height == newHeight && this->samples == newSamples && this->mipLevels == newMipLevels)
-				return;
-
-			if (preserveData && this->samples != samples)
-				throw HardwareRendererException("Sample count must be identical to preserve data");
-
-			vk::Image oldImage = image;
-			vk::ImageView oldView = view;
-			vk::DeviceMemory oldMemory = memory;
-
-			int oldWidth = this->width;
-			int oldHeight = this->height;
-			int oldMipLevels = this->mipLevels;
-
+			// Create texture resources
 			vk::ImageAspectFlags aspectFlags = vk::ImageAspectFlagBits::eColor;
 			vk::ImageUsageFlags usageFlags;
 			if (!!(usage & TextureUsage::ColorAttachment))
@@ -1064,15 +1012,14 @@ namespace VK
 				usageFlags |= vk::ImageUsageFlagBits::eSampled;
 			}
 
-			// Create texture resources
 			vk::ImageCreateInfo imageCreateInfo = vk::ImageCreateInfo()
 				.setFlags(vk::ImageCreateFlags())
 				.setImageType(vk::ImageType::e2D)
 				.setFormat(TranslateStorageFormat(format))
-				.setExtent(vk::Extent3D(newWidth, newHeight, 1))
-				.setMipLevels(newMipLevels)
-				.setArrayLayers(1)
-				.setSamples(SampleCount(newSamples))
+				.setExtent(vk::Extent3D(width, height, 1))
+				.setMipLevels(mipLevels)
+				.setArrayLayers(arrayLayers)
+				.setSamples(SampleCount(numSamples))
 				.setTiling(vk::ImageTiling::eOptimal)
 				.setUsage(vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eTransferDst | usageFlags)
 				.setSharingMode(vk::SharingMode::eExclusive)
@@ -1094,9 +1041,9 @@ namespace VK
 			vk::ImageSubresourceRange imageSubresourceRange = vk::ImageSubresourceRange()
 				.setAspectMask(aspectFlags)
 				.setBaseMipLevel(0)
-				.setLevelCount(newMipLevels)
+				.setLevelCount(mipLevels)
 				.setBaseArrayLayer(0)
-				.setLayerCount(1);
+				.setLayerCount(arrayLayers);
 
 			vk::ImageViewCreateInfo imageViewCreateInfo = vk::ImageViewCreateInfo()
 				.setFlags(vk::ImageViewCreateFlags())
@@ -1107,40 +1054,48 @@ namespace VK
 				.setSubresourceRange(imageSubresourceRange);
 
 			view = RendererState::Device().createImageView(imageViewCreateInfo).value;
-
-			if (preserveData)
-			{
-				if (!oldImage || !oldView || !oldMemory)
-					throw HardwareRendererException("There is no data to preserve");
-
-				(void)oldWidth, oldHeight, oldMipLevels;
-				//TODO: blit the image from the old to new image here
-			}
-
-			// Free old resources
-			if (oldMemory) RendererState::Device().freeMemory(oldMemory);
-			if (oldView) RendererState::Device().destroyImageView(oldView);
-			if (oldImage) RendererState::Device().destroyImage(oldImage);
-
-			// Set texture parameters
-			this->width = newWidth;
-			this->height = newHeight;
-			this->samples = newSamples;
-			this->mipLevels = newMipLevels;
 		}
-		void SetData(StorageFormat pformat, int level, int pwidth, int pheight, int numSamples, DataType inputType, void* data, bool mipmapped = true)
+		~Texture()
+		{
+			RendererState::Device().waitIdle(); //TODO: Remove
+			if (memory) RendererState::Device().freeMemory(memory);
+			if (view) RendererState::Device().destroyImageView(view);
+			if (image) RendererState::Device().destroyImage(image);
+		}
+
+		void SetData(int mipLevel, int width, int height, int depth, int layerOffset, int numLayers) {
+
+		}
+	};
+
+	class Texture2D : public VK::Texture, public GameEngine::Texture2D
+	{
+		//TODO: Need some way of determining layouts and performing transitions properly. 
+	public:
+		int width;
+		int height;
+		int samples = 1;
+		int arrayLayers = 1;
+		int mipLevels = 1;
+		vk::ImageLayout currentLayout;
+
+		Texture2D(TextureUsage usage, int width, int height, int mipLevelCount, StorageFormat format)
+			: VK::Texture(usage, width, height, 1, mipLevelCount, 1, 1, format)
+		{
+			this->width = width;
+			this->height = height;
+			this->mipLevels = mipLevelCount;
+		};
+
+		void GetSize(int& pwidth, int& pheight)
+		{
+			pwidth = width;
+			pheight = height;
+		}
+		void SetData(int level, int pwidth, int pheight, int numSamples, DataType inputType, void* data)
 		{
 			if (numSamples > 1)
 				throw HardwareRendererException("samples must be equal to 1");
-
-			format = pformat;
-			if (level == 0)
-			{
-				if (mipmapped)
-					Resize(pwidth, pheight, numSamples, (int)std::floor(std::log2(max(pwidth, pheight))) + 1);
-				else
-					Resize(pwidth, pheight, numSamples);
-			}
 
 			if (data == nullptr)
 			{
@@ -1497,9 +1452,9 @@ namespace VK
 			}
 			this->currentLayout = LayoutFromUsage(this->usage);
 		}
-		void SetData(StorageFormat pformat, int pwidth, int pheight, int numSamples, DataType inputType, void* data, bool mipmapped = true)
+		void SetData(int pwidth, int pheight, int numSamples, DataType inputType, void* data)
 		{
-			SetData(pformat, 0, pwidth, pheight, numSamples, inputType, data, mipmapped);
+			SetData(0, pwidth, pheight, numSamples, inputType, data);
 		}
 		void BuildMipmaps()
 		{
@@ -1907,6 +1862,35 @@ namespace VK
 			// Destroy staging resources
 			RendererState::Device().freeMemory(stagingMemory);
 			RendererState::Device().destroyBuffer(stagingBuffer);
+		}
+	};
+
+	class Texture2DArray : public VK::Texture, public GameEngine::Texture2DArray
+	{
+	private:
+		int width;
+		int height;
+		int arrayLayers;
+	public:
+		Texture2DArray(TextureUsage usage, int width, int height, int mipLevels, int arrayLayers, StorageFormat newFormat)
+			: VK::Texture(usage, width, height, 1, mipLevels, arrayLayers, 1, newFormat)
+		{
+			this->format = newFormat;
+		};
+
+		virtual void GetSize(int& pwidth, int& pheight, int& players) override
+		{
+			pwidth = this->width;
+			pheight = this->height;
+			players = this->arrayLayers;
+		}
+
+		virtual void SetData(int mipLevel, int xOffset, int yOffset, int layerOffset, int pwidth, int pheight, int layerCount, DataType inputType, void * data) override
+		{
+		}
+
+		virtual void BuildMipmaps() override
+		{
 		}
 	};
 
@@ -2608,8 +2592,8 @@ namespace VK
 					usage = dynamic_cast<Texture2D*>(renderAttachments.attachments[colorReference.attachment].handle.tex2D)->usage;
 				else if (renderAttachments.attachments[colorReference.attachment].handle.tex2DArray)
 				{
-					throw CoreLib::NotImplementedException();
-					//usage = dynamic_cast<Texture2DArray*>(renderAttachments.attachments[colorReference.attachment].handle.tex2DArray)->usage;
+					//throw CoreLib::NotImplementedException();
+					usage = dynamic_cast<Texture2DArray*>(renderAttachments.attachments[colorReference.attachment].handle.tex2DArray)->usage;
 				}
 
 				if (!(usage & TextureUsage::ColorAttachment))
@@ -2622,8 +2606,8 @@ namespace VK
 					usage = dynamic_cast<Texture2D*>(renderAttachments.attachments[depthReference.attachment].handle.tex2D)->usage;
 				else if (renderAttachments.attachments[depthReference.attachment].handle.tex2DArray)
 				{
-					throw CoreLib::NotImplementedException();
-					//usage = dynamic_cast<Texture2DArray*>(renderAttachments.attachments[depthReference.attachment].handle.tex2DArray)->usage;
+					//throw CoreLib::NotImplementedException();
+					usage = dynamic_cast<Texture2DArray*>(renderAttachments.attachments[depthReference.attachment].handle.tex2DArray)->usage;
 				}
 				if (!(usage & TextureUsage::DepthAttachment))
 					throw HardwareRendererException("Incompatible RenderTargetLayout and RenderAttachments");
@@ -2635,9 +2619,12 @@ namespace VK
 			CoreLib::List<vk::ImageView> framebufferAttachmentViews;
 			for (auto attachment : renderAttachments.attachments)
 			{
-				if (attachment.handle.tex2DArray)
-					throw CoreLib::NotImplementedException();
-				framebufferAttachmentViews.Add(dynamic_cast<Texture2D*>(attachment.handle.tex2D)->view);
+				//if (attachment.handle.tex2DArray)
+				//throw CoreLib::NotImplementedException();
+				if (attachment.handle.tex2D)
+					framebufferAttachmentViews.Add(dynamic_cast<Texture2D*>(attachment.handle.tex2D)->view);
+				else if (attachment.handle.tex2DArray)
+					framebufferAttachmentViews.Add(dynamic_cast<Texture2DArray*>(attachment.handle.tex2DArray)->view);
 			}
 
 			vk::FramebufferCreateInfo framebufferCreateInfo = vk::FramebufferCreateInfo()
@@ -3450,7 +3437,7 @@ namespace VK
 		{
 			CoreLib::List<vk::ClearAttachment> attachments;
 			CoreLib::List<vk::ClearRect> rects;
-			
+
 			for (int k = 0; k < renderAttachments.Count(); k++)
 			{
 				vk::ImageAspectFlags aspectMask;
@@ -3493,7 +3480,7 @@ namespace VK
 				vk::ArrayProxy<const vk::ClearAttachment>(attachments.Count(), attachments.Buffer()),
 				vk::ArrayProxy<const vk::ClearRect>(rects.Count(), rects.Buffer())
 			);
-			
+
 		}
 	};
 
@@ -4188,17 +4175,17 @@ namespace VK
 			return new BufferObject(TranslateUsageFlags(usage), vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent);
 		}
 
-		Texture2D* CreateTexture2D(TextureUsage usage)
+		Texture2D* CreateTexture2D(TextureUsage usage, int width, int height, int mipLevelCount, StorageFormat format)
 		{
-			return new Texture2D(usage);
+			return new Texture2D(usage, width, height, mipLevelCount, format);
 		}
 
-		Texture2DArray * CreateTexture2DArray(TextureUsage /*usage*/, int /*w*/, int /*h*/, int /*layers*/, int /*mipLevelCount*/, StorageFormat /*pFormat*/)
+		Texture2DArray * CreateTexture2DArray(TextureUsage usage, int w, int h, int layers, int mipLevelCount, StorageFormat format)
 		{
-			throw CoreLib::NotImplementedException();
+			return new Texture2DArray(usage, w, h, mipLevelCount, layers, format);
 		}
 
-		Texture3D * CreateTexture3D(TextureUsage /*usage*/, int /*w*/, int /*h*/, int /*layers*/, int /*mipLevelCount*/, StorageFormat /*pFormat*/)
+		Texture3D * CreateTexture3D(TextureUsage /*usage*/, int /*w*/, int /*h*/, int /*layers*/, int /*mipLevelCount*/, StorageFormat /*format*/)
 		{
 			throw CoreLib::NotImplementedException();
 		}


### PR DESCRIPTION
This commit changes the Texture2D interface to mirror the way Texture2DArray and Texture3D are implemented.

Calling CreateTexture2D should now allocate resources to be used for the Texture, and the Resize function has been removed. Additional parameters are required to create a Texture2D that were previously given in SetData.


Also moves VulkanHardwareRenderer to VulkanAPI to mirror OpenGL, and adds camera constraints to debug.level